### PR TITLE
bug: CCS-3687 CCS-3686 Fix markup so rhdocs css applies

### DIFF
--- a/elements/cp-documentation/src/cp-documentation.html
+++ b/elements/cp-documentation/src/cp-documentation.html
@@ -1,1 +1,1 @@
-<div id="wrapper"></div>
+<div id="wrapper" class="rhdocs"></div>


### PR DESCRIPTION
Didn't have a wrapper with the rhdocs class so no CSS was applying properly